### PR TITLE
WIP: message count first time

### DIFF
--- a/src/android/WebimSDK.java
+++ b/src/android/WebimSDK.java
@@ -150,7 +150,9 @@ public class WebimSDK extends CordovaPlugin {
     private void init(final JSONObject args, final CallbackContext callbackContext)
             throws JSONException {
         if (session != null) {
+            CallbackContext savedUnreadHandler = onUnreadByVisitorMessageCountCallback;
             close(null);
+            onUnreadByVisitorMessageCountCallback = savedUnreadHandler;
         }
         if (!args.has("accountName")) {
             sendCallbackError(callbackContext, "{\"result\":\"Missing required parameters\"}");


### PR DESCRIPTION
Исправлен баг когда close() в init очищал onUnreadByVisitorMessageCount. тем самым не позволяя при повторном init правильно повесить обработчик. Если Вешать до инициализации то close() сотрет. Если после - потеряно самое первое событие и теперь уже хендлер вызовется только при изменении счетчика непрочитанных сообщений.